### PR TITLE
Fix buffer load and add regression test

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -25,6 +25,19 @@ def test_replay_buffer_add_single():
     assert len(buffer) == 1
     assert buffer.buffer[0] == exp
 
+
+def test_replay_buffer_save_load(tmp_path):
+    """Ensure ReplayBuffer.load can load a previously saved buffer."""
+    buffer = ReplayBuffer(capacity=5)
+    exp = (np.zeros((3, 6, 7)), np.zeros(7), 0.0)
+    buffer.add(exp)
+
+    file_path = tmp_path / "buffer.pt"
+    buffer.save(file_path)
+
+    loaded = ReplayBuffer.load(file_path, capacity=5)
+    assert len(loaded) == 1
+
 def test_board_dataset_empty():
     """
     Test that BoardDataset correctly handles an empty input.

--- a/train_alphazero.py
+++ b/train_alphazero.py
@@ -73,7 +73,7 @@ class ReplayBuffer:
         """
         buffer = ReplayBuffer(capacity)
         if os.path.exists(path):
-            buffer.buffer = deque(torch.load(path, weights_only=False), maxlen=capacity)
+            buffer.buffer = deque(torch.load(path), maxlen=capacity)
         return buffer
 
 


### PR DESCRIPTION
## Summary
- ensure ReplayBuffer.load calls `torch.load` without unsupported `weights_only` arg
- test that ReplayBuffer.load works on a saved buffer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed05f58688322b39d220977c746ba