### PR TITLE
Fix player tracking in MCTS and add expansion test

### DIFF
--- a/agents/agent_MCTS/mcts.py
+++ b/agents/agent_MCTS/mcts.py
@@ -93,8 +93,11 @@ class MCTSAgent:
 
             # === SELECTION ===
             node = self.selection_process(node)
+            player = node.player
+
             # === EXPANSION ===
             node = self.expansion(node, player)
+            player = node.player
 
             # === SIMULATION ===
             result = node.result if node.is_terminal else self.simulate(node, player)

--- a/tests/test_mcts_child_player_after_expansion.py
+++ b/tests/test_mcts_child_player_after_expansion.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from agents.agent_MCTS.mcts import MCTSAgent
+from agents.agent_MCTS.node import Node
+from game_utils import (
+    initialize_game_state,
+    PLAYER1,
+    PLAYER2,
+    PlayerAction,
+    apply_player_action,
+    get_opponent,
+)
+
+
+def test_child_node_player_after_expansion():
+    board = initialize_game_state()
+    root_node = Node(state=board, player=PLAYER1)
+
+    action = PlayerAction(0)
+    next_state = board.copy()
+    apply_player_action(next_state, action, PLAYER1)
+    child_node = root_node.expand(action, next_state, PLAYER2)
+
+    root_node.untried_actions = set()
+
+    agent = MCTSAgent(iterationnumber=1)
+    agent.mcts_move(board.copy(), PLAYER1, root_node)
+
+    assert child_node.children, "Child node should have a child after expansion"
+    grandchild = next(iter(child_node.children.values()))
+    expected_player = get_opponent(child_node.player)
+    assert grandchild.player == expected_player


### PR DESCRIPTION
## Summary
- update `mcts.py` to keep track of the current player after selection and expansion
- test expansion inserts child node with the correct player

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed05eb3a48322a18c6967080e2a22