### PR TITLE
Fix policy loss and add test

### DIFF
--- a/agents/alphazero/network.py
+++ b/agents/alphazero/network.py
@@ -110,6 +110,9 @@ class CustomLoss(nn.Module):
         super().__init__()
 
     def forward(self, target_value, predicted_value, target_policy, predicted_policy):
+        target_value = target_value.to(predicted_value.device)
+        target_policy = target_policy.to(predicted_policy.device)
         value_loss = (predicted_value - target_value) ** 2
-        policy_loss = torch.sum(-predicted_policy * (1e-8 + target_policy).log(), dim=1)
-        return (value_loss.view(-1) + policy_loss).mean()
+        policy_loss = torch.sum(
+            -target_policy * torch.log(predicted_policy + 1e-8), dim=1
+        )        return (value_loss.view(-1) + policy_loss).mean()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -230,3 +230,21 @@ def test_dataloader_integration():
         assert policies.shape == (2, 7)
         assert values.shape == (2, 1)
         break
+
+
+def test_custom_loss_policy_improvement():
+    """Loss decreases as predicted policy approaches the target."""
+    loss_fn = CustomLoss()
+
+    target_policy = torch.tensor([[0.7, 0.1, 0.2, 0, 0, 0, 0]], dtype=torch.float32)
+    target_value = torch.tensor([[0.0]], dtype=torch.float32)
+
+    pred_policy_far = torch.full((1, 7), 1 / 7, dtype=torch.float32)
+    pred_value = torch.tensor([[0.0]], dtype=torch.float32)
+
+    loss_far = loss_fn(target_value, pred_value, target_policy, pred_policy_far)
+
+    pred_policy_close = 0.5 * pred_policy_far + 0.5 * target_policy
+    loss_close = loss_fn(target_value, pred_value, target_policy, pred_policy_close)
+
+    assert loss_close < loss_far


### PR DESCRIPTION
## Summary
- update policy loss in `CustomLoss`
- ensure targets move to same device as predictions
- test that `CustomLoss` decreases as predicted policy approaches target

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed05dca348322a07e8150ed52b3c6