### PR TITLE
Fix policy input for AlphaZero inference

### DIFF
--- a/agents/agent_MCTS/alphazero_mcts.py
+++ b/agents/agent_MCTS/alphazero_mcts.py
@@ -30,8 +30,9 @@ class AlphazeroMCTSAgent(MCTSAgent):
         Initializes the AlphaZero MCTS agent.
 
         Args:
-            policy_value (callable): A function that takes a board state and returns a tuple of
-                                    (policy: Dict[action, prior], value: float).
+            policy_value (callable): A function that takes a board state and the
+                current player and returns a tuple of
+                (policy: Dict[action, prior], value: float).
             iterationnumber (int): Number of MCTS iterations per move.
         """
         super().__init__(iterationnumber)
@@ -51,7 +52,7 @@ class AlphazeroMCTSAgent(MCTSAgent):
         if node.is_terminal:
             return node.result
 
-        _, value = self.policy_value(node.state)
+        _, value = self.policy_value(node.state, node.player)
         # Return value from the root player’s perspective
         return {PLAYER1: value, PLAYER2: 1 - value}
 
@@ -83,7 +84,7 @@ class AlphazeroMCTSAgent(MCTSAgent):
         if node.is_terminal or node.is_fully_expanded():
             return node
 
-        policy, _ = self.policy_value(node.state)
+        policy, _ = self.policy_value(node.state, node.player)
         for action in node.untried_actions.copy():
             next_state = node.state.copy()
             apply_player_action(next_state, action, player)

--- a/agents/alphazero/inference.py
+++ b/agents/alphazero/inference.py
@@ -1,17 +1,28 @@
 import torch
 import numpy as np
-from game_utils import check_move_status, MoveStatus, PlayerAction, BOARD_ROWS, BOARD_COLS
+from game_utils import (
+    check_move_status,
+    MoveStatus,
+    PlayerAction,
+    BOARD_ROWS,
+    BOARD_COLS,
+    get_opponent,
+)
 
-def policy_value(state: np.ndarray, model: torch.nn.Module, device='cpu'):
+def policy_value(
+    state: np.ndarray,
+    model: torch.nn.Module,
+    current_player: int,
+    device: str = "cpu",
+):
     """
     Given a board state, returns:
     - A dict mapping legal moves (actions) to prior probabilities
     - A scalar value estimate for the current player
     """
     model.eval()
-    
-    current_player = 1  # Or get this from your state/game logic
-    opponent_player = 2 if current_player == 1 else 1
+
+    opponent_player = get_opponent(current_player)
 
     # Create planes
     plane_current = (state == current_player).astype(np.float32)

--- a/main.py
+++ b/main.py
@@ -184,7 +184,7 @@ def run_alphazero_vs_random(num_games: int, alpha_iterations=100):
     model.eval()
     
     alpha_agent = AlphazeroMCTSAgent(
-        policy_value=lambda state: policy_value(state, model),
+        policy_value=lambda state, player: policy_value(state, model, player),
         iterationnumber=alpha_iterations
     )
     
@@ -270,7 +270,7 @@ def run_alphazero_vs_mcts(num_games: int, alpha_iterations=100):
     model.eval()
     
     alpha_agent = AlphazeroMCTSAgent(
-        policy_value=lambda state: policy_value(state, model),
+        policy_value=lambda state, player: policy_value(state, model, player),
         iterationnumber=alpha_iterations
     )
     

--- a/train_alphazero.py
+++ b/train_alphazero.py
@@ -128,7 +128,7 @@ def self_play(model, device, mcts_iterations=100, temperature=1.0):
     """
     board = initialize_game_state()
     agent = AlphazeroMCTSAgent(
-        lambda state: policy_value(state, model, device),
+        lambda state, player: policy_value(state, model, player, device),
         iterationnumber=mcts_iterations
     )
     saved_state = None


### PR DESCRIPTION
## Summary
- allow `policy_value` to receive `current_player`
- compute opponent using `get_opponent`
- pass player value from AlphaZero MCTS and training loops

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ed056505c8322bc4cbdf680547b40