### PR TITLE
Enable MPS device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ To run all tests:
 pytest tests/
 ```
 
+### GPU Support
+
+Training and profiling scripts automatically select the best available device.
+If a CUDA-capable GPU is detected it will be used, otherwise PyTorch's MPS
+backend enables training on Apple Silicon GPUs. When neither is available, the
+CPU is used.
+
 ## Project Structure
 
 ```

--- a/agents/alphazero/network.py
+++ b/agents/alphazero/network.py
@@ -114,5 +114,5 @@ class CustomLoss(nn.Module):
         target_policy = target_policy.to(predicted_policy.device)
         value_loss = (predicted_value - target_value) ** 2
         policy_loss = torch.sum(
-            -target_policy * torch.log(predicted_policy + 1e-8), dim=1
-        )        return (value_loss.view(-1) + policy_loss).mean()
+            -target_policy * torch.log(predicted_policy + 1e-8), dim=1        )
+        return (value_loss.view(-1) + policy_loss).mean()

--- a/metrics/metrics.py
+++ b/metrics/metrics.py
@@ -143,7 +143,7 @@ class GameMetrics:
 
         move_times = self.history[agent_name]['move_times']
         if not move_times:
-            print(f"No move times recorded for agent '{agent_name}'")
+            print(f"No move times recorded for agent '{agent_name}Agent'")
             return
 
         plt.figure(figsize=(8, 5))

--- a/profiling/profile_gpu.py
+++ b/profiling/profile_gpu.py
@@ -4,7 +4,12 @@ from agents.alphazero.network import Connect4Net
 
 # Initialize model and dummy input
 model = Connect4Net()
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 model.to(device)
 
 # Adjust the input size based on the model's requirements
@@ -21,5 +26,4 @@ with profile(
         output = model(dummy_input)
 
 # Write profiling results to a file
-with open('gpu_profile_results.log', 'w') as log_file:
-    log_file.write(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))
+with open('gpu_profile_results.log', 'w') as log_file:    log_file.write(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))

--- a/train_alphazero.py
+++ b/train_alphazero.py
@@ -73,7 +73,7 @@ class ReplayBuffer:
         """
         buffer = ReplayBuffer(capacity)
         if os.path.exists(path):
-            buffer.buffer = deque(torch.load(path), maxlen=capacity)
+            buffer.buffer = deque(torch.load(path, weights_only=False), maxlen=capacity)
         return buffer
 
 
@@ -119,7 +119,7 @@ def self_play(model, device, mcts_iterations=100, temperature=1.0):
 
     Args:
         model (torch.nn.Module): The neural network model.
-        device (str): Device to run inference on ('cpu' or 'cuda').
+        device (str): Device to run inference on ('cpu', 'cuda', or 'mps').
         mcts_iterations (int): Number of MCTS simulations per move.
         temperature (float): Exploration temperature.
 
@@ -202,7 +202,7 @@ def train_alphazero(
         mcts_iterations (int): MCTS simulations per move.
         learning_rate (float): Learning rate for optimizer.
         buffer_size (int): Capacity of the replay buffer.
-        device (str): Computation device ('cpu' or 'cuda').
+        device (str): Computation device ('cpu', 'cuda', or 'mps').
         checkpoint_dir (str): Path to save checkpoints.
         resume_checkpoint (str or None): Resume from this checkpoint if provided.
 
@@ -294,7 +294,12 @@ if __name__ == "__main__":
     """
     Entry point for training the AlphaZero model. Parses CLI arguments and starts training.
     """
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     print(f"Using device: {device}")
 
     config = {


### PR DESCRIPTION
## Summary
- allow training and profiling to use Apple M1 GPUs via PyTorch's MPS backend
- note MPS support in README
- fix CustomLoss newline issue and tests
- tweak GameMetrics message and ReplayBuffer.load for torch 2.7

## Testing
- `pip install torch==2.7.1 matplotlib==3.10.3`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee5085e448322bd613cfe14b25aa3