### PR TITLE
Add default device helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://miro.com/app/board/uXjVIsyA0Qk=/
    ```
    pip install -r requirements.txt
    ```
+   PyTorch will automatically use CUDA or Apple's MPS backend if available.
 
 ### Running Simulations
 

--- a/agents/alphazero/train_dummy_data.py
+++ b/agents/alphazero/train_dummy_data.py
@@ -2,6 +2,7 @@ import torch
 from torch.utils.data import DataLoader
 import numpy as np
 from network import Connect4Net, BoardDataset, CustomLoss
+from utils.device import get_default_device
 
 
 # Generate dummy data (replace with self-play later)
@@ -29,8 +30,10 @@ data = generate_dummy_data(500)
 dataset = BoardDataset(data)
 loader = DataLoader(dataset, batch_size=32, shuffle=True)
 
+device = get_default_device()
+
 # Initialize model and training components
-model = Connect4Net()
+model = Connect4Net().to(device)
 loss_fn = CustomLoss()
 optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 
@@ -39,9 +42,9 @@ for epoch in range(5):  # Start with just 5 epochs
     total_loss = 0
     for batch in loader:
         states, target_policy, target_value = batch
-        states = states.float()
-        target_policy = target_policy.float()
-        target_value = target_value.float()
+        states = states.float().to(device)
+        target_policy = target_policy.float().to(device)
+        target_value = target_value.float().to(device)
 
         pred_policy, pred_value = model(states)
         loss = loss_fn(target_value, pred_value, target_policy, pred_policy)

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from agents.agent_MCTS.mcts import MCTSAgent
 from agents.agent_MCTS.hierarchical_mcts import HierarchicalMCTSAgent
 from agents.agent_MCTS.alphazero_mcts import AlphazeroMCTSAgent
 from agents.alphazero.network import Connect4Net
+from utils.device import get_default_device
 from agents.alphazero.inference import policy_value
 import torch 
 
@@ -178,8 +179,9 @@ def run_alphazero_vs_random(num_games: int, alpha_iterations=100):
     total_metrics = GameMetrics()
     
     # Initialize agent
-    model = Connect4Net()
-    checkpoint = torch.load("checkpoints/iteration_40.pt", map_location="cpu")
+    device = get_default_device()
+    model = Connect4Net().to(device)
+    checkpoint = torch.load("checkpoints/iteration_40.pt", map_location=device)
     model.load_state_dict(checkpoint['model_state_dict'])
     model.eval()
     
@@ -264,8 +266,9 @@ def run_alphazero_vs_mcts(num_games: int, alpha_iterations=100):
     total_metrics = GameMetrics()
     
     # Initialize agent
-    model = Connect4Net()
-    checkpoint = torch.load("checkpoints/iteration_20.pt", map_location="cpu")
+    device = get_default_device()
+    model = Connect4Net().to(device)
+    checkpoint = torch.load("checkpoints/iteration_20.pt", map_location=device)
     model.load_state_dict(checkpoint['model_state_dict'])
     model.eval()
     

--- a/profiling/profile_gpu.py
+++ b/profiling/profile_gpu.py
@@ -1,10 +1,11 @@
 import torch
 from torch.profiler import profile, record_function, ProfilerActivity
 from agents.alphazero.network import Connect4Net
+from utils.device import get_default_device
 
 # Initialize model and dummy input
 model = Connect4Net()
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = get_default_device()
 model.to(device)
 
 # Adjust the input size based on the model's requirements

--- a/train_alphazero.py
+++ b/train_alphazero.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 import torch.optim as optim
 from torch.utils.data import DataLoader, Dataset
+from utils.device import get_default_device
 import os
 import time
 from collections import deque
@@ -295,7 +296,7 @@ if __name__ == "__main__":
     """
     Entry point for training the AlphaZero model. Parses CLI arguments and starts training.
     """
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = get_default_device()
     print(f"Using device: {device}")
 
     config = {

--- a/utils/device.py
+++ b/utils/device.py
@@ -1,0 +1,9 @@
+import torch
+
+def get_default_device():
+    """Return the best available torch device (MPS, CUDA or CPU)."""
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    elif torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")


### PR DESCRIPTION
## Summary
- implement `utils.device.get_default_device`
- use the helper in `train_alphazero.py` and `main.py`
- update `train_dummy_data.py` and GPU profiling to pick best device
- mention MPS support in README
- include helper module in repo

## Testing
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'matplotlib', torch)*

------
https://chatgpt.com/codex/tasks/task_e_686f7b4a6964832284f34656539ed1a5