### PR TITLE
Fix AlphaZero MCTS value orientation

### DIFF
--- a/agents/agent_MCTS/alphazero_mcts.py
+++ b/agents/agent_MCTS/alphazero_mcts.py
@@ -53,8 +53,9 @@ class AlphazeroMCTSAgent(MCTSAgent):
             return node.result
 
         _, value = self.policy_value(node.state, node.player)
-        # Return value from the root player’s perspective
-        return {PLAYER1: value, PLAYER2: 1 - value}
+        # The network's value is from the perspective of the player to move.
+        # Convert it into per‑player scores for backpropagation.
+        return {player: value, get_opponent(player): -value}
 
     def selection_process(self, node: Node) -> Node:
         """


### PR DESCRIPTION
## Summary
- correct value propagation in `AlphazeroMCTSAgent.simulate`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcdbda7048322809c265fdd6ec7c8